### PR TITLE
新規登録、ログイン画面のデザインを修正する

### DIFF
--- a/front/assets/variables.scss
+++ b/front/assets/variables.scss
@@ -2,3 +2,19 @@
 //
 // The variables you want to modify
 // $font-size-root: 20px;
+.height-fullfilled {
+  height: 100vh;
+}
+
+.img-responsive {
+  max-width: 100%;
+  height: auto;
+}
+
+.v-main__wrap {
+  min-height: 100vh;
+}
+
+.width-fullfilled {
+  width: 100%;
+}

--- a/front/layouts/welcome.vue
+++ b/front/layouts/welcome.vue
@@ -14,17 +14,3 @@ export default {
   },
 }
 </script>
-<style>
-.height-fullfilled {
-  height: 100vh;
-}
-
-.width-fullfilled {
-  width: 100%;
-}
-
-.img-responsive {
-  max-width: 100%;
-  height: auto;
-}
-</style>

--- a/front/pages/login.vue
+++ b/front/pages/login.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-container>
-    <v-row class="justify-center">
-      <v-col sm="12" md="5">
+  <v-container class="height-fullfilled d-flex justify-center align-center">
+    <v-row>
+      <v-col cols="10" offset="1" sm="6" offset-sm="3" md="4" offset-md="4">
         <h2 class="text-center subtitle-1 font-weight-bold mb-2">
           メールアドレスでログイン
         </h2>
@@ -17,7 +17,6 @@
               <v-tab to="/login">ログイン</v-tab>
               <v-tab to="/signup">アカウント登録</v-tab>
             </v-tabs>
-
             <v-row>
               <v-col sm="12">
                 <v-card flat>
@@ -32,7 +31,6 @@
                         label="メールアドレス"
                         required
                       />
-
                       <v-text-field
                         v-model="password"
                         label="パスワード"
@@ -41,11 +39,9 @@
                         :type="showPassword ? 'text' : 'password'"
                         @click:append="showPassword = !showPassword"
                       />
-
                       <v-alert v-if="loginErrorMsg" dense text type="error">
                         {{ loginErrorMsg }}
                       </v-alert>
-
                       <v-btn
                         :disabled="!login_valid"
                         color="blue darken-3"
@@ -69,6 +65,7 @@
 <script>
 export default {
   name: 'Login',
+  layout: 'welcome',
   data() {
     return {
       tab: null,

--- a/front/pages/signup.vue
+++ b/front/pages/signup.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-container>
-    <v-row justify="center">
-      <v-col sm="12" md="5">
+  <v-container class="height-fullfilled d-flex justify-center align-center">
+    <v-row>
+      <v-col cols="10" offset="1" sm="6" offset-sm="3" md="4" offset-md="4">
         <h2 class="text-center subtitle-1 font-weight-bold mb-2">
           メールアドレスで登録
         </h2>
@@ -17,7 +17,6 @@
               <v-tab to="/login">ログイン</v-tab>
               <v-tab to="/signup">アカウント登録</v-tab>
             </v-tabs>
-
             <v-row>
               <v-col sm="12">
                 <v-card flat>
@@ -40,7 +39,6 @@
                         required
                         :rules="[rules.required, rules.email]"
                       />
-
                       <v-text-field
                         v-model="password"
                         label="パスワード"
@@ -54,14 +52,6 @@
                         :type="showPassword ? 'text' : 'password'"
                         @click:append="showPassword = !showPassword"
                       >
-                        <!-- <template v-slot:progress>
-                          <v-progress-linear
-                            :value="score.value"
-                            :color="score.color"
-                            absolute
-                            height="2"
-                          />
-                        </template> -->
                       </v-text-field>
                       <v-text-field
                         v-model="passwordConfirmation"
@@ -78,11 +68,9 @@
                         :type="showPassword ? 'text' : 'password'"
                         @click:append="showPassword = !showPassword"
                       />
-
                       <v-alert v-if="registerErrorMsg" dense text type="error">
                         {{ registerErrorMsg }}
                       </v-alert>
-
                       <v-btn
                         :disabled="!isValid || loading"
                         :loading="loading"
@@ -98,7 +86,6 @@
                 </v-card>
               </v-col>
             </v-row>
-            <!-- <v-divider class="my-8" /> -->
           </v-col>
         </v-row>
       </v-col>
@@ -112,6 +99,7 @@
 // :disabled="!isValid || loading"
 export default {
   name: 'Signup',
+  layout: 'welcome',
   data() {
     return {
       registerErrorMsg: '',
@@ -212,3 +200,12 @@ export default {
   },
 }
 </script>
+<style scoped>
+/* .v-application--wrap {
+  min-height: 100vh;
+} */
+
+/* .v-main {
+  min-height: 100vh;
+} */
+</style>

--- a/front/stylelint.config.js
+++ b/front/stylelint.config.js
@@ -7,5 +7,8 @@ module.exports = {
   ],
   // add your custom config here
   // https://stylelint.io/user-guide/configuration
-  rules: {},
+  rules: {
+    // [既存プロジェクトをStylelint v14にアップグレードするときに注意すべき点 – ブログの設置](https://flex-box.net/stylelint-v14/)
+    'selector-class-pattern': null,
+  },
 }


### PR DESCRIPTION
今まではNuxt.jsのCLIで自動生成されたレイアウトをそのまま使用していた。
新規登録、ログイン画面では自動生成されたレイアウトはよけいな情報があるのでできるだけ削除して使用するようにする。

#### PRでやったこと

- デザインの修正、レスポンシブ化
- `signup.vue`、`login.vue`のlayoutファイルを`layout/welcome.vue`に変更
- 共通cssを`variables.scss`に追加
- SCSSのLinterの設定を追加